### PR TITLE
Adding 'Previous Role' to the reconfiguration text (Deployed replica case)

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
@@ -73,11 +73,10 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
     }
 
     public get role(): string {
-        const { PartitionStatus } = this.partition;
         const { ReconfigurationInformation, ReplicaRole } = this.raw;
         const PreviousReplicaRole = ReconfigurationInformation.PreviousConfigurationRole;
-    
-        if (PartitionStatus !== 'Reconfiguring') {
+
+        if (!this.partition || this.partition.PartitionStatus !== 'Reconfiguring') {
             return ReplicaRole;
         }
     

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
@@ -74,12 +74,12 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
 
     public get role(): string {
         const { ReconfigurationInformation, ReplicaRole } = this.raw;
-        const PreviousReplicaRole = ReconfigurationInformation.PreviousConfigurationRole;
 
         if (!this.partition || this.partition.PartitionStatus !== 'Reconfiguring') {
             return ReplicaRole;
         }
     
+        const PreviousReplicaRole = ReconfigurationInformation.PreviousConfigurationRole;
         if (!PreviousReplicaRole || PreviousReplicaRole === 'None') {
             return `Reconfiguring - Target Role: ${ReplicaRole}`;
         }

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
@@ -87,7 +87,6 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
         return `Reconfiguring: ${PreviousReplicaRole} ${UnicodeConstants.RightArrow} ${ReplicaRole}`;
     }
 
-
     public get viewPath(): string {
         return RoutesService.getDeployedReplicaViewPath(this.parent.parent.parent.name, this.parent.parent.id, this.parent.id, this.parent.servicePackageActivationId, this.raw.PartitionId, this.id);
     }

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -84,8 +84,7 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
             return `Reconfiguring - Target Role: ${ReplicaRole}`;
         }
     
-        const roleTransition = PreviousReplicaRole === ReplicaRole ? ReplicaRole : `${PreviousReplicaRole} ${UnicodeConstants.RightArrow} ${ReplicaRole}`;
-        return `Reconfiguring: ${roleTransition}`;
+        return `Reconfiguring: ${PreviousReplicaRole} ${UnicodeConstants.RightArrow} ${ReplicaRole}`;
     }
 
     public get currentRole(): string {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -579,6 +579,13 @@ export interface IRawReplicaHealth extends IRawHealth {
         InstanceId: string;
     }
 
+export interface IReconfigurationInformation {
+    PreviousConfigurationRole: string;
+    ReconfigurationPhase: string;
+    ReconfigurationType: string;
+    ReconfigurationStartTimeUtc: string;
+}
+
 export interface IRawDeployedReplica {
     Address: string;
     CodePackageName: string;
@@ -586,6 +593,7 @@ export interface IRawDeployedReplica {
     LastInBuildDurationInSeconds: string;
     ReplicaId: string;
     PartitionId: string;
+    ReconfigurationInformation: IReconfigurationInformation;
     ReplicaRole: string;
     ReplicaStatus: string;
     ServiceKind: string;
@@ -594,8 +602,6 @@ export interface IRawDeployedReplica {
     ServiceTypeName: string;
     ServicePackageActivationId: string;
 }
-
-
 
 export interface IRawDeployedReplicaDetail {
     PartitionId: string;


### PR DESCRIPTION
Adding changes in accordance with the existing [Pull request](https://github.com/microsoft/service-fabric-explorer/pull/874/files) for the Deployed replica case.

Screenshot of the deployed replica part:
![Screenshot 2024-11-26 133748](https://github.com/user-attachments/assets/6e2b450f-22e1-423c-9f8f-d469d94c6b98)
